### PR TITLE
Update field_contributor.rst

### DIFF
--- a/docs/field_contributor.rst
+++ b/docs/field_contributor.rst
@@ -106,10 +106,10 @@ Example
    :linenos:
 
    <datacite:contributors>
-	   <datacite:contributor>
+	   <datacite:contributor contributorType="ContactPerson">
 	     <datacite:contributorName>Evans, R. J.</datacite:contributorName>
 	   <datacite:contributor>
-	   <datacite:contributor>
+	   <datacite:contributor contributorType="HostingInstitution">
 	     <datacite:contributorName>International Human Genome Sequencing Consortium</datacite:contributorName>
 	   </datacite:contributor>
    </datacite:contributors>


### PR DESCRIPTION
The contributor field should have a mandatory attribute contributorType. However, in the example in the page, the contributorType is not specified.